### PR TITLE
Implement getHeadOriginal

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ repository = git.open('/Users/me/repos/node')
 
 ### Repository.getDiffStats(path)
 
-### Repository.getHeadOriginal(path)
+### Repository.getHeadBlob(path)
 
 Similar to `git show HEAD:<path>`. Retrieves the blob as defined in HEAD.
 

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -190,7 +190,7 @@ describe "git", ->
         fs.writeFileSync(filePath, 'changing\nb.txt\nwith lines', 'utf8')
         expect(repo.getDiffStats('b.txt')).toEqual {added: 0, deleted: 0}
 
-  describe '.getHeadOriginal(path)', ->
+  describe '.getHeadBlob(path)', ->
     repo = null
 
     beforeEach ->
@@ -202,18 +202,11 @@ describe "git", ->
       it 'returns the original', ->
         filePath = path.join(repo.getWorkingDirectory(), 'a.txt')
         fs.writeFileSync(filePath, 'changing\na.txt', 'utf8')
-        expect(repo.getHeadOriginal('a.txt')).toBe 'first line\n'
+        expect(repo.getHeadBlob('a.txt')).toBe 'first line\n'
 
     describe 'when a path is not modified', ->
       it 'returns the original', ->
-        expect(repo.getHeadOriginal('a.txt')).toBe 'first line\n'
-
-    # TODO: commits don't exist yet
-    # describe 'when a path is modified, then committed', ->
-    #   it 'returns the committed content', ->
-    #     filePath = path.join(repo.getWorkingDirectory(), 'a.txt')
-    #     fs.writeFileSync(filePath, 'changing\na.txt', 'utf8')
-    #     expect(repo.getHeadOriginal('a.txt')).toBe 'first line\n'
+        expect(repo.getHeadBlob('a.txt')).toBe 'first line\n'
 
   describe '.getStatus([path])', ->
     repo = null

--- a/src/repository.cc
+++ b/src/repository.cc
@@ -45,8 +45,8 @@ void Repository::Init(Handle<Object> target) {
   Local<Function> getDiffStats = FunctionTemplate::New(Repository::GetDiffStats)->GetFunction();
   tpl->PrototypeTemplate()->Set(String::NewSymbol("getDiffStats"), getDiffStats);
 
-  Local<Function> GetHeadOriginal = FunctionTemplate::New(Repository::GetHeadOriginal)->GetFunction();
-  tpl->PrototypeTemplate()->Set(String::NewSymbol("getHeadOriginal"), GetHeadOriginal);
+  Local<Function> GetHeadBlob = FunctionTemplate::New(Repository::GetHeadBlob)->GetFunction();
+  tpl->PrototypeTemplate()->Set(String::NewSymbol("getHeadBlob"), GetHeadBlob);
 
   Local<Function> getCommitCount = FunctionTemplate::New(Repository::GetCommitCount)->GetFunction();
   tpl->PrototypeTemplate()->Set(String::NewSymbol("getCommitCount"), getCommitCount);
@@ -326,7 +326,7 @@ Handle<Value> Repository::GetDiffStats(const Arguments& args) {
   return scope.Close(result);
 }
 
-Handle<Value> Repository::GetHeadOriginal(const Arguments& args) {
+Handle<Value> Repository::GetHeadBlob(const Arguments& args) {
   HandleScope scope;
   if (args.Length() < 1)
     return scope.Close(Null());
@@ -363,8 +363,10 @@ Handle<Value> Repository::GetHeadOriginal(const Arguments& args) {
   git_tree_free(tree);
   if (blob == NULL)
     return scope.Close(Null());
-  const char *content = (const char *) git_blob_rawcontent(blob);
 
+  const char *content = (const char *) git_blob_rawcontent(blob);
+  git_blob_free(blob);
+  
   return scope.Close(String::NewSymbol(content));
 }
 

--- a/src/repository.h
+++ b/src/repository.h
@@ -21,7 +21,7 @@ class Repository : public node::ObjectWrap {
     static Handle<Value> CheckoutHead(const Arguments& args);
     static Handle<Value> GetReferenceTarget(const Arguments& args);
     static Handle<Value> GetDiffStats(const Arguments& args);
-    static Handle<Value> GetHeadOriginal(const Arguments& args);
+    static Handle<Value> GetHeadBlob(const Arguments& args);
     static Handle<Value> GetCommitCount(const Arguments& args);
     static Handle<Value> GetMergeBase(const Arguments& args);
     static Handle<Value> Release(const Arguments& args);


### PR DESCRIPTION
I want to use [diff-match-patch](https://code.google.com/p/google-diff-match-patch/) to show changes in a single file.

This API will get me something similar to `git show HEAD:<path>`, which will be considered the "original." I can then match that against whatever the current file buffer is.
