### PR TITLE
Lazy loading of submodules

### DIFF
--- a/src/git.coffee
+++ b/src/git.coffee
@@ -157,6 +157,9 @@ Repository::submoduleForPath = (path) ->
   path = @relativize(path)
   return null unless path
 
+  if @submodules instanceof Function
+    @submodules()
+
   for submodulePath, submoduleRepo of @submodules
     if path is submodulePath
       return submoduleRepo
@@ -228,5 +231,6 @@ openSubmodules = (repository) ->
 
 exports.open = (repositoryPath) ->
   repository = openRepository(repositoryPath)
-  openSubmodules(repository) if repository?
+  if repository?
+    repository.submodules = -> openSubmodules(repository)
   repository


### PR DESCRIPTION
I'm trying to solve one particular problem — to get a branch name for a repository inside a given path.

I'm doing
```js
var GitUtils = require('git-utils')
console.log(GitUtils.open(path).getShortHead())
```

But `open` performs too slow on sshfs. It takes about 5 or 6 seconds to `getSubmodulePaths`. The other code takes about 10 ms.

I suggest to delay `openSubmodules` for the time when it will be needed, and to not call it in `open`.