### PR TITLE
Update nan package dependency from 1.6.1 to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "grunt-coffeelint": "0.0.6"
   },
   "dependencies": {
-    "nan": "https://atom.io/download/atom-shell/nan-1.6.1.tgz",
+    "nan": "^2.0.0",
     "fs-plus": "^2.1.0"
   },
   "scripts": {

--- a/src/repository.cc
+++ b/src/repository.cc
@@ -26,67 +26,68 @@
 #include <map>
 #include <utility>
 
-void Repository::Init(Handle<Object> target) {
-  NanScope();
-
+void Repository::Init(Local<Object> target) {
+  Nan::HandleScope scope;
   git_threads_init();
 
-  Local<FunctionTemplate> newTemplate = NanNew<FunctionTemplate>(
+  Local<FunctionTemplate> newTemplate = Nan::New<FunctionTemplate>(
       Repository::New);
-  newTemplate->SetClassName(NanNew<String>("Repository"));
+  newTemplate->SetClassName(Nan::New<String>("Repository").ToLocalChecked());
   newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
 
   Local<ObjectTemplate> proto = newTemplate->PrototypeTemplate();
-  NODE_SET_METHOD(proto, "getPath", Repository::GetPath);
-  NODE_SET_METHOD(proto, "_getWorkingDirectory",
+  Nan::SetMethod(proto, "getPath", Repository::GetPath);
+  Nan::SetMethod(proto, "_getWorkingDirectory",
                   Repository::GetWorkingDirectory);
-  NODE_SET_METHOD(proto, "exists", Repository::Exists);
-  NODE_SET_METHOD(proto, "getSubmodulePaths", Repository::GetSubmodulePaths);
-  NODE_SET_METHOD(proto, "getHead", Repository::GetHead);
-  NODE_SET_METHOD(proto, "refreshIndex", Repository::RefreshIndex);
-  NODE_SET_METHOD(proto, "isIgnored", Repository::IsIgnored);
-  NODE_SET_METHOD(proto, "isSubmodule", Repository::IsSubmodule);
-  NODE_SET_METHOD(proto, "getConfigValue", Repository::GetConfigValue);
-  NODE_SET_METHOD(proto, "setConfigValue", Repository::SetConfigValue);
-  NODE_SET_METHOD(proto, "getStatus", Repository::GetStatus);
-  NODE_SET_METHOD(proto, "checkoutHead", Repository::CheckoutHead);
-  NODE_SET_METHOD(proto, "getReferenceTarget", Repository::GetReferenceTarget);
-  NODE_SET_METHOD(proto, "getDiffStats", Repository::GetDiffStats);
-  NODE_SET_METHOD(proto, "getIndexBlob", Repository::GetIndexBlob);
-  NODE_SET_METHOD(proto, "getHeadBlob", Repository::GetHeadBlob);
-  NODE_SET_METHOD(proto, "getCommitCount", Repository::GetCommitCount);
-  NODE_SET_METHOD(proto, "getMergeBase", Repository::GetMergeBase);
-  NODE_SET_METHOD(proto, "_release", Repository::Release);
-  NODE_SET_METHOD(proto, "getLineDiffs", Repository::GetLineDiffs);
-  NODE_SET_METHOD(proto, "getLineDiffDetails", Repository::GetLineDiffDetails);
-  NODE_SET_METHOD(proto, "getReferences", Repository::GetReferences);
-  NODE_SET_METHOD(proto, "checkoutRef", Repository::CheckoutReference);
-  NODE_SET_METHOD(proto, "add", Repository::Add);
+  Nan::SetMethod(proto, "exists", Repository::Exists);
+  Nan::SetMethod(proto, "getSubmodulePaths", Repository::GetSubmodulePaths);
+  Nan::SetMethod(proto, "getHead", Repository::GetHead);
+  Nan::SetMethod(proto, "refreshIndex", Repository::RefreshIndex);
+  Nan::SetMethod(proto, "isIgnored", Repository::IsIgnored);
+  Nan::SetMethod(proto, "isSubmodule", Repository::IsSubmodule);
+  Nan::SetMethod(proto, "getConfigValue", Repository::GetConfigValue);
+  Nan::SetMethod(proto, "setConfigValue", Repository::SetConfigValue);
+  Nan::SetMethod(proto, "getStatus", Repository::GetStatus);
+  Nan::SetMethod(proto, "checkoutHead", Repository::CheckoutHead);
+  Nan::SetMethod(proto, "getReferenceTarget", Repository::GetReferenceTarget);
+  Nan::SetMethod(proto, "getDiffStats", Repository::GetDiffStats);
+  Nan::SetMethod(proto, "getIndexBlob", Repository::GetIndexBlob);
+  Nan::SetMethod(proto, "getHeadBlob", Repository::GetHeadBlob);
+  Nan::SetMethod(proto, "getCommitCount", Repository::GetCommitCount);
+  Nan::SetMethod(proto, "getMergeBase", Repository::GetMergeBase);
+  Nan::SetMethod(proto, "_release", Repository::Release);
+  Nan::SetMethod(proto, "getLineDiffs", Repository::GetLineDiffs);
+  Nan::SetMethod(proto, "getLineDiffDetails", Repository::GetLineDiffDetails);
+  Nan::SetMethod(proto, "getReferences", Repository::GetReferences);
+  Nan::SetMethod(proto, "checkoutRef", Repository::CheckoutReference);
+  Nan::SetMethod(proto, "add", Repository::Add);
 
-  target->Set(NanNew<String>("Repository"), newTemplate->GetFunction());
+  target->Set(Nan::New<String>("Repository").ToLocalChecked(),
+                                newTemplate->GetFunction());
 }
 
 NODE_MODULE(git, Repository::Init)
 
 NAN_METHOD(Repository::New) {
-  NanScope();
-  Repository* repository = new Repository(Local<String>::Cast(args[0]));
-  repository->Wrap(args.This());
-  NanReturnUndefined();
+  Nan::HandleScope scope;
+  Repository* repository = new Repository(Local<String>::Cast(info[0]));
+  repository->Wrap(info.This());
+  info.GetReturnValue().SetUndefined();
 }
 
-git_repository* Repository::GetRepository(_NAN_METHOD_ARGS_TYPE args) {
-  return node::ObjectWrap::Unwrap<Repository>(args.This())->repository;
+git_repository* Repository::GetRepository(Nan::NAN_METHOD_ARGS_TYPE args) {
+  return Nan::ObjectWrap::Unwrap<Repository>(args.This())->repository;
 }
 
-int Repository::GetBlob(_NAN_METHOD_ARGS_TYPE args,
+int Repository::GetBlob(Nan::NAN_METHOD_ARGS_TYPE args,
                         git_repository* repo, git_blob*& blob) {
   std::string path(*String::Utf8Value(args[0]));
 
   int useIndex = false;
   if (args.Length() >= 3) {
     Local<Object> optionsArg(Local<Object>::Cast(args[2]));
-    if (optionsArg->Get(NanNew<String>("useIndex"))->BooleanValue())
+    if (optionsArg->Get(
+        Nan::New<String>("useIndex").ToLocalChecked())->BooleanValue())
       useIndex = true;
   }
 
@@ -152,41 +153,43 @@ git_diff_options Repository::CreateDefaultGitDiffOptions() {
 }
 
 NAN_METHOD(Repository::Exists) {
-  NanScope();
-  NanReturnValue(NanNew<Boolean>(GetRepository(args) != NULL));
+  Nan::HandleScope scope;
+
+  info.GetReturnValue().Set(Nan::New<Boolean>(GetRepository(info) != NULL));
 }
 
 NAN_METHOD(Repository::GetPath) {
-  NanScope();
-  git_repository* repository = GetRepository(args);
+  Nan::HandleScope scope;
+  git_repository* repository = GetRepository(info);
   const char* path = git_repository_path(repository);
-  NanReturnValue(NanNew<String>(path));
+
+  info.GetReturnValue().Set(Nan::New<String>(path).ToLocalChecked());
 }
 
 NAN_METHOD(Repository::GetWorkingDirectory) {
-  NanScope();
-  git_repository* repository = GetRepository(args);
+  Nan::HandleScope scope;
+  git_repository* repository = GetRepository(info);
   const char* path = git_repository_workdir(repository);
-  NanReturnValue(NanNew<String>(path));
+  info.GetReturnValue().Set(Nan::New<String>(path).ToLocalChecked());
 }
 
 NAN_METHOD(Repository::GetSubmodulePaths) {
-  NanScope();
-  git_repository* repository = GetRepository(args);
+  Nan::HandleScope scope;
+  git_repository* repository = GetRepository(info);
   std::vector<std::string> paths;
   git_submodule_foreach(repository, SubmoduleCallback, &paths);
-  Local<Object> v8Paths = NanNew<Array>(paths.size());
+  Local<Object> v8Paths = Nan::New<Array>(paths.size());
   for (size_t i = 0; i < paths.size(); i++)
-    v8Paths->Set(i, NanNew<String>(paths[i].data()));
-  NanReturnValue(v8Paths);
+    v8Paths->Set(i, Nan::New<String>(paths[i].data()).ToLocalChecked());
+  info.GetReturnValue().Set(v8Paths);
 }
 
 NAN_METHOD(Repository::GetHead) {
-  NanScope();
-  git_repository* repository = GetRepository(args);
+  Nan::HandleScope scope;
+  git_repository* repository = GetRepository(info);
   git_reference* head;
   if (git_repository_head(&head, repository) != GIT_OK)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
   if (git_repository_head_detached(repository) == 1) {
     const git_oid* sha = git_reference_target(head);
@@ -194,139 +197,141 @@ NAN_METHOD(Repository::GetHead) {
       char oid[GIT_OID_HEXSZ + 1];
       git_oid_tostr(oid, GIT_OID_HEXSZ + 1, sha);
       git_reference_free(head);
-      NanReturnValue(NanNew<String>(oid, -1));
+      return info.GetReturnValue().Set(Nan::New<String>(oid, -1)
+                                        .ToLocalChecked());
     }
   }
 
-  Local<String> referenceName = NanNew<String>(git_reference_name(head));
+  Local<String> referenceName = Nan::New<String>(git_reference_name(head))
+                                    .ToLocalChecked();
   git_reference_free(head);
-  NanReturnValue(referenceName);
+  return info.GetReturnValue().Set(referenceName);
 }
 
 NAN_METHOD(Repository::RefreshIndex) {
-  NanScope();
-  git_repository* repository = GetRepository(args);
+  Nan::HandleScope scope;
+  git_repository* repository = GetRepository(info);
   git_index* index;
   if (git_repository_index(&index, repository) == GIT_OK) {
     git_index_read(index, 0);
     git_index_free(index);
   }
-  NanReturnUndefined();
+  info.GetReturnValue().SetUndefined();
 }
 
 NAN_METHOD(Repository::IsIgnored) {
-  NanScope();
-  if (args.Length() < 1)
-    NanReturnValue(NanNew<Boolean>(false));
+  Nan::HandleScope scope;
+  if (info.Length() < 1)
+    return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 
-  git_repository* repository = GetRepository(args);
-  std::string path(*String::Utf8Value(args[0]));
+  git_repository* repository = GetRepository(info);
+  std::string path(*String::Utf8Value(info[0]));
   int ignored;
   if (git_ignore_path_is_ignored(&ignored,
                                  repository,
                                  path.c_str()) == GIT_OK)
-    NanReturnValue(NanNew<Boolean>(ignored == 1));
+    return info.GetReturnValue().Set(Nan::New<Boolean>(ignored == 1));
   else
-    NanReturnValue(NanNew<Boolean>(false));
+    return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 }
 
 NAN_METHOD(Repository::IsSubmodule) {
-  NanScope();
-  if (args.Length() < 1)
-    NanReturnValue(NanNew<Boolean>(false));
+  Nan::HandleScope scope;
+  if (info.Length() < 1)
+    return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 
   git_index* index;
-  git_repository* repository = GetRepository(args);
+  git_repository* repository = GetRepository(info);
   if (git_repository_index(&index, repository) == GIT_OK) {
-    std::string path(*String::Utf8Value(args[0]));
+    std::string path(*String::Utf8Value(info[0]));
     const git_index_entry* entry = git_index_get_bypath(index, path.c_str(), 0);
-    Handle<Boolean> isSubmodule = NanNew<Boolean>(
+    Local<Boolean> isSubmodule = Nan::New<Boolean>(
         entry != NULL && (entry->mode & S_IFMT) == GIT_FILEMODE_COMMIT);
     git_index_free(index);
-    NanReturnValue(isSubmodule);
+    return info.GetReturnValue().Set(isSubmodule);
   } else {
-    NanReturnValue(NanNew<Boolean>(false));
+    return info.GetReturnValue().Set(Nan::New<Boolean>(false));
   }
 }
 
 NAN_METHOD(Repository::GetConfigValue) {
-  NanScope();
-  if (args.Length() < 1)
-    NanReturnNull();
+  Nan::HandleScope scope;
+  if (info.Length() < 1)
+    return info.GetReturnValue().Set(Nan::Null());
 
   git_config* config;
-  git_repository* repository = GetRepository(args);
+  git_repository* repository = GetRepository(info);
   if (git_repository_config(&config, repository) != GIT_OK)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
-  std::string configKey(*String::Utf8Value(args[0]));
+  std::string configKey(*String::Utf8Value(info[0]));
   const char* configValue;
   if (git_config_get_string(
         &configValue, config, configKey.c_str()) == GIT_OK) {
-    Handle<String> configValueHandle = NanNew<String>(configValue);
     git_config_free(config);
-    NanReturnValue(configValueHandle);
+    return info.GetReturnValue().Set(Nan::New<String>(configValue)
+                                      .ToLocalChecked());
   } else {
     git_config_free(config);
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
   }
 }
 
 NAN_METHOD(Repository::SetConfigValue) {
-  NanScope();
-  if (args.Length() != 2)
-    NanReturnValue(NanNew<Boolean>(false));
+  Nan::HandleScope scope;
+  if (info.Length() != 2)
+    return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 
   git_config* config;
-  git_repository* repository = GetRepository(args);
+  git_repository* repository = GetRepository(info);
   if (git_repository_config(&config, repository) != GIT_OK)
-    NanReturnValue(NanNew<Boolean>(false));
+    return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 
-  std::string configKey(*String::Utf8Value(args[0]));
-  std::string configValue(*String::Utf8Value(args[1]));
+  std::string configKey(*String::Utf8Value(info[0]));
+  std::string configValue(*String::Utf8Value(info[1]));
 
   int errorCode = git_config_set_string(
       config, configKey.c_str(), configValue.c_str());
   git_config_free(config);
-  NanReturnValue(NanNew<Boolean>(errorCode == GIT_OK));
+  return info.GetReturnValue().Set(Nan::New<Boolean>(errorCode == GIT_OK));
 }
 
 
 NAN_METHOD(Repository::GetStatus) {
-  NanScope();
-  if (args.Length() < 1) {
-    Local<Object> result = NanNew<Object>();
+  Nan::HandleScope scope;
+  if (info.Length() < 1) {
+    Local<Object> result = Nan::New<Object>();
     std::map<std::string, unsigned int> statuses;
     git_status_options options = GIT_STATUS_OPTIONS_INIT;
     options.flags = GIT_STATUS_OPT_INCLUDE_UNTRACKED |
                     GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS;
-    if (git_status_foreach_ext(GetRepository(args),
+    if (git_status_foreach_ext(GetRepository(info),
                                &options,
                                StatusCallback,
                                &statuses) == GIT_OK) {
       std::map<std::string, unsigned int>::iterator iter = statuses.begin();
       for (; iter != statuses.end(); ++iter)
-        result->Set(NanNew<String>(iter->first.c_str()),
-                    NanNew<Number>(iter->second));
+        result->Set(Nan::New<String>(iter->first.c_str()).ToLocalChecked(),
+                    Nan::New<Number>(iter->second));
     }
-    NanReturnValue(result);
+    return info.GetReturnValue().Set(result);
   } else {
-    git_repository* repository = GetRepository(args);
-    std::string path(*String::Utf8Value(args[0]));
+    git_repository* repository = GetRepository(info);
+    std::string path(*String::Utf8Value(info[0]));
     unsigned int status = 0;
     if (git_status_file(&status, repository, path.c_str()) == GIT_OK)
-      NanReturnValue(NanNew<Number>(status));
+      return info.GetReturnValue().Set(Nan::New<Number>(status));
     else
-      NanReturnValue(NanNew<Number>(0));
+      return info.GetReturnValue().Set(Nan::New<Number>(0));
   }
 }
 
 NAN_METHOD(Repository::CheckoutHead) {
-  NanScope();
-  if (args.Length() < 1)
-    NanReturnValue(NanNew<Boolean>(false));
+  Nan::HandleScope scope;
+  if (info.Length() < 1)
+    return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 
-  String::Utf8Value utf8Path(args[0]);
+  String::Utf8Value utf8Path(info[0]);
   char* path = *utf8Path;
 
   git_checkout_options options = GIT_CHECKOUT_OPTIONS_INIT;
@@ -337,58 +342,61 @@ NAN_METHOD(Repository::CheckoutHead) {
   paths.strings = &path;
   options.paths = paths;
 
-  int result = git_checkout_head(GetRepository(args), &options);
-  NanReturnValue(NanNew<Boolean>(result == GIT_OK));
+  int result = git_checkout_head(GetRepository(info), &options);
+  return info.GetReturnValue().Set(Nan::New<Boolean>(result == GIT_OK));
 }
 
 NAN_METHOD(Repository::GetReferenceTarget) {
-  NanScope();
-  if (args.Length() < 1)
-    NanReturnNull();
+  Nan::HandleScope scope;
+  if (info.Length() < 1)
+    return info.GetReturnValue().Set(Nan::Null());
 
-  std::string refName(*String::Utf8Value(args[0]));
+  std::string refName(*String::Utf8Value(info[0]));
   git_oid sha;
   if (git_reference_name_to_id(
-        &sha, GetRepository(args), refName.c_str()) == GIT_OK) {
+        &sha, GetRepository(info), refName.c_str()) == GIT_OK) {
     char oid[GIT_OID_HEXSZ + 1];
     git_oid_tostr(oid, GIT_OID_HEXSZ + 1, &sha);
-    NanReturnValue(NanNew<String>(oid, -1));
+    return info.GetReturnValue().Set(Nan::New<String>(oid, -1)
+                                  .ToLocalChecked());
   } else {
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
   }
 }
 
 NAN_METHOD(Repository::GetDiffStats) {
-  NanScope();
+  Nan::HandleScope scope;
 
   int added = 0;
   int deleted = 0;
-  Local<Object> result = NanNew<Object>();
-  result->Set(NanNew<String>("added"), NanNew<Number>(added));
-  result->Set(NanNew<String>("deleted"), NanNew<Number>(deleted));
+  Local<Object> result = Nan::New<Object>();
+  result->Set(Nan::New<String>("added").ToLocalChecked(),
+                Nan::New<Number>(added));
+  result->Set(Nan::New<String>("deleted").ToLocalChecked(),
+                Nan::New<Number>(deleted));
 
-  if (args.Length() < 1)
-    NanReturnValue(result);
+  if (info.Length() < 1)
+    return info.GetReturnValue().Set(result);
 
-  git_repository* repository = GetRepository(args);
+  git_repository* repository = GetRepository(info);
   git_reference* head;
   if (git_repository_head(&head, repository) != GIT_OK)
-    NanReturnValue(result);
+    return info.GetReturnValue().Set(result);
 
   const git_oid* sha = git_reference_target(head);
   git_commit* commit;
   int commitStatus = git_commit_lookup(&commit, repository, sha);
   git_reference_free(head);
   if (commitStatus != GIT_OK)
-    NanReturnValue(result);
+    return info.GetReturnValue().Set(result);
 
   git_tree* tree;
   int treeStatus = git_commit_tree(&tree, commit);
   git_commit_free(commit);
   if (treeStatus != GIT_OK)
-    NanReturnValue(result);
+    return info.GetReturnValue().Set(result);
 
-  String::Utf8Value utf8Path(args[0]);
+  String::Utf8Value utf8Path(info[0]);
   char* path = *utf8Path;
 
   git_diff_options options = CreateDefaultGitDiffOptions();
@@ -403,19 +411,19 @@ NAN_METHOD(Repository::GetDiffStats) {
   int diffStatus = git_diff_tree_to_workdir(&diffs, repository, tree, &options);
   git_tree_free(tree);
   if (diffStatus != GIT_OK)
-    NanReturnValue(result);
+    return info.GetReturnValue().Set(result);
 
   int deltas = git_diff_num_deltas(diffs);
   if (deltas != 1) {
     git_diff_free(diffs);
-    NanReturnValue(result);
+    return info.GetReturnValue().Set(result);
   }
 
   git_patch* patch;
   int patchStatus = git_patch_from_diff(&patch, diffs, 0);
   git_diff_free(diffs);
   if (patchStatus != GIT_OK)
-    NanReturnValue(result);
+    return info.GetReturnValue().Set(result);
 
   int hunks = git_patch_num_hunks(patch);
   for (int i = 0; i < hunks; i++) {
@@ -436,40 +444,43 @@ NAN_METHOD(Repository::GetDiffStats) {
   }
   git_patch_free(patch);
 
-  result->Set(NanNew<String>("added"), NanNew<Number>(added));
-  result->Set(NanNew<String>("deleted"), NanNew<Number>(deleted));
-  NanReturnValue(result);
+  result->Set(Nan::New<String>("added").ToLocalChecked(),
+                Nan::New<Number>(added));
+  result->Set(Nan::New<String>("deleted").ToLocalChecked(),
+                Nan::New<Number>(deleted));
+
+  return info.GetReturnValue().Set(result);
 }
 
 NAN_METHOD(Repository::GetHeadBlob) {
-  NanScope();
-  if (args.Length() < 1)
-    NanReturnNull();
+  Nan::HandleScope scope;
+  if (info.Length() < 1)
+    return info.GetReturnValue().Set(Nan::Null());
 
-  std::string path(*String::Utf8Value(args[0]));
+  std::string path(*String::Utf8Value(info[0]));
 
-  git_repository* repo = GetRepository(args);
+  git_repository* repo = GetRepository(info);
   git_reference* head;
   if (git_repository_head(&head, repo) != GIT_OK)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
   const git_oid* sha = git_reference_target(head);
   git_commit* commit;
   int commitStatus = git_commit_lookup(&commit, repo, sha);
   git_reference_free(head);
   if (commitStatus != GIT_OK)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
   git_tree* tree;
   int treeStatus = git_commit_tree(&tree, commit);
   git_commit_free(commit);
   if (treeStatus != GIT_OK)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
   git_tree_entry* treeEntry;
   if (git_tree_entry_bypath(&treeEntry, tree, path.c_str()) != GIT_OK) {
     git_tree_free(tree);
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
   }
 
   git_blob* blob = NULL;
@@ -479,31 +490,31 @@ NAN_METHOD(Repository::GetHeadBlob) {
   git_tree_entry_free(treeEntry);
   git_tree_free(tree);
   if (blob == NULL)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
   const char* content = static_cast<const char*>(git_blob_rawcontent(blob));
-  Handle<Value> value = NanNew<String>(content);
+  Local<Value> value = Nan::New<String>(content).ToLocalChecked();
   git_blob_free(blob);
-  NanReturnValue(value);
+  return info.GetReturnValue().Set(value);
 }
 
 NAN_METHOD(Repository::GetIndexBlob) {
-  NanScope();
-  if (args.Length() < 1)
-    NanReturnNull();
+  Nan::HandleScope scope;
+  if (info.Length() < 1)
+    return info.GetReturnValue().Set(Nan::Null());
 
-  std::string path(*String::Utf8Value(args[0]));
+  std::string path(*String::Utf8Value(info[0]));
 
-  git_repository* repo = GetRepository(args);
+  git_repository* repo = GetRepository(info);
   git_index* index;
   if (git_repository_index(&index, repo) != GIT_OK)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
   git_index_read(index, 0);
   const git_index_entry* entry = git_index_get_bypath(index, path.data(), 0);
   if (entry == NULL) {
     git_index_free(index);
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
   }
 
   git_blob* blob = NULL;
@@ -512,12 +523,12 @@ NAN_METHOD(Repository::GetIndexBlob) {
     blob = NULL;
   git_index_free(index);
   if (blob == NULL)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
   const char* content = static_cast<const char*>(git_blob_rawcontent(blob));
-  Handle<Value> value = NanNew<String>(content);
+  Local<Value> value = Nan::New<String>(content).ToLocalChecked();
   git_blob_free(blob);
-  NanReturnValue(value);
+  return info.GetReturnValue().Set(value);
 }
 
 int Repository::StatusCallback(
@@ -539,33 +550,33 @@ int Repository::SubmoduleCallback(
 }
 
 NAN_METHOD(Repository::Release) {
-  NanScope();
-  Repository* repo = node::ObjectWrap::Unwrap<Repository>(args.This());
+  Nan::HandleScope scope;
+  Repository* repo = Nan::ObjectWrap::Unwrap<Repository>(info.This());
   if (repo->repository != NULL) {
     git_repository_free(repo->repository);
     repo->repository = NULL;
   }
-  NanReturnUndefined();
+  info.GetReturnValue().SetUndefined();
 }
 
 NAN_METHOD(Repository::GetCommitCount) {
-  NanScope();
-  if (args.Length() < 2)
-    NanReturnValue(NanNew<Number>(0));
+  Nan::HandleScope scope;
+  if (info.Length() < 2)
+    return info.GetReturnValue().Set(Nan::New<Number>(0));
 
-  std::string fromCommitId(*String::Utf8Value(args[0]));
+  std::string fromCommitId(*String::Utf8Value(info[0]));
   git_oid fromCommit;
   if (git_oid_fromstr(&fromCommit, fromCommitId.c_str()) != GIT_OK)
-    NanReturnValue(NanNew<Number>(0));
+    return info.GetReturnValue().Set(Nan::New<Number>(0));
 
-  std::string toCommitId(*String::Utf8Value(args[1]));
+  std::string toCommitId(*String::Utf8Value(info[1]));
   git_oid toCommit;
   if (git_oid_fromstr(&toCommit, toCommitId.c_str()) != GIT_OK)
-    NanReturnValue(NanNew<Number>(0));
+    return info.GetReturnValue().Set(Nan::New<Number>(0));
 
   git_revwalk* revWalk;
-  if (git_revwalk_new(&revWalk, GetRepository(args)) != GIT_OK)
-    NanReturnValue(NanNew<Number>(0));
+  if (git_revwalk_new(&revWalk, GetRepository(info)) != GIT_OK)
+    return info.GetReturnValue().Set(Nan::New<Number>(0));
 
   git_revwalk_push(revWalk, &fromCommit);
   git_revwalk_hide(revWalk, &toCommit);
@@ -574,33 +585,34 @@ NAN_METHOD(Repository::GetCommitCount) {
   while (git_revwalk_next(&currentCommit, revWalk) == GIT_OK)
     count++;
   git_revwalk_free(revWalk);
-  NanReturnValue(NanNew<Number>(count));
+  return info.GetReturnValue().Set(Nan::New<Number>(count));
 }
 
 NAN_METHOD(Repository::GetMergeBase) {
-  NanScope();
-  if (args.Length() < 2)
-    NanReturnNull();
+  Nan::HandleScope scope;
+  if (info.Length() < 2)
+    return info.GetReturnValue().Set(Nan::Null());
 
-  std::string commitOneId(*String::Utf8Value(args[0]));
+  std::string commitOneId(*String::Utf8Value(info[0]));
   git_oid commitOne;
   if (git_oid_fromstr(&commitOne, commitOneId.c_str()) != GIT_OK)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
-  std::string commitTwoId(*String::Utf8Value(args[1]));
+  std::string commitTwoId(*String::Utf8Value(info[1]));
   git_oid commitTwo;
   if (git_oid_fromstr(&commitTwo, commitTwoId.c_str()) != GIT_OK)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
   git_oid mergeBase;
   if (git_merge_base(
-        &mergeBase, GetRepository(args), &commitOne, &commitTwo) == GIT_OK) {
+        &mergeBase, GetRepository(info), &commitOne, &commitTwo) == GIT_OK) {
     char mergeBaseId[GIT_OID_HEXSZ + 1];
     git_oid_tostr(mergeBaseId, GIT_OID_HEXSZ + 1, &mergeBase);
-    NanReturnValue(NanNew<String>(mergeBaseId, -1));
+    return info.GetReturnValue().Set(Nan::New<String>(mergeBaseId, -1)
+        .ToLocalChecked());
   }
 
-  NanReturnNull();
+  return info.GetReturnValue().Set(Nan::Null());
 }
 
 int Repository::DiffHunkCallback(const git_diff_delta* delta,
@@ -613,28 +625,32 @@ int Repository::DiffHunkCallback(const git_diff_delta* delta,
 }
 
 NAN_METHOD(Repository::GetLineDiffs) {
-  NanScope();
-  if (args.Length() < 2)
-    NanReturnNull();
+  Nan::HandleScope scope;
+  if (info.Length() < 2)
+    return info.GetReturnValue().Set(Nan::Null());
 
-  std::string text(*String::Utf8Value(args[1]));
+  std::string text(*String::Utf8Value(info[1]));
 
-  git_repository* repo = GetRepository(args);
+  git_repository* repo = GetRepository(info);
 
   git_blob* blob = NULL;
 
-  int getBlobResult = GetBlob(args, repo, blob);
+  int getBlobResult = GetBlob(info, repo, blob);
 
   if (getBlobResult != 0)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
   std::vector<git_diff_hunk> ranges;
   git_diff_options options = CreateDefaultGitDiffOptions();
 
   // Set GIT_DIFF_IGNORE_WHITESPACE_EOL when ignoreEolWhitespace: true
-  if (args.Length() >= 3) {
-    Local<Object> optionsArg(Local<Object>::Cast(args[2]));
-    if (optionsArg->Get(NanNew<String>("ignoreEolWhitespace"))->BooleanValue())
+  if (info.Length() >= 3) {
+    Local<Object> optionsArg(Local<Object>::Cast(info[2]));
+    Local<Value> ignoreEolWhitespace;
+    ignoreEolWhitespace = optionsArg->Get(
+        Nan::New<String>("ignoreEolWhitespace").ToLocalChecked());
+
+    if (ignoreEolWhitespace->BooleanValue())
       options.flags = GIT_DIFF_IGNORE_WHITESPACE_EOL;
   }
 
@@ -642,24 +658,24 @@ NAN_METHOD(Repository::GetLineDiffs) {
   if (git_diff_blob_to_buffer(blob, NULL, text.data(), text.length(), NULL,
                               &options, NULL, DiffHunkCallback, NULL,
                               &ranges) == GIT_OK) {
-    Local<Object> v8Ranges = NanNew<Array>(ranges.size());
+    Local<Object> v8Ranges = Nan::New<Array>(ranges.size());
     for (size_t i = 0; i < ranges.size(); i++) {
-      Local<Object> v8Range = NanNew<Object>();
-      v8Range->Set(NanNew<String>("oldStart"),
-                   NanNew<Number>(ranges[i].old_start));
-      v8Range->Set(NanNew<String>("oldLines"),
-                   NanNew<Number>(ranges[i].old_lines));
-      v8Range->Set(NanNew<String>("newStart"),
-                   NanNew<Number>(ranges[i].new_start));
-      v8Range->Set(NanNew<String>("newLines"),
-                   NanNew<Number>(ranges[i].new_lines));
+      Local<Object> v8Range = Nan::New<Object>();
+      v8Range->Set(Nan::New<String>("oldStart").ToLocalChecked(),
+                   Nan::New<Number>(ranges[i].old_start));
+      v8Range->Set(Nan::New<String>("oldLines").ToLocalChecked(),
+                   Nan::New<Number>(ranges[i].old_lines));
+      v8Range->Set(Nan::New<String>("newStart").ToLocalChecked(),
+                   Nan::New<Number>(ranges[i].new_start));
+      v8Range->Set(Nan::New<String>("newLines").ToLocalChecked(),
+                   Nan::New<Number>(ranges[i].new_lines));
       v8Ranges->Set(i, v8Range);
     }
     git_blob_free(blob);
-    NanReturnValue(v8Ranges);
+    return info.GetReturnValue().Set(v8Ranges);
   } else {
     git_blob_free(blob);
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
   }
 }
 
@@ -682,28 +698,32 @@ int Repository::DiffLineCallback(const git_diff_delta* delta,
 }
 
 NAN_METHOD(Repository::GetLineDiffDetails) {
-  NanScope();
-  if (args.Length() < 2)
-    NanReturnNull();
+  Nan::HandleScope scope;
+  if (info.Length() < 2)
+    return info.GetReturnValue().Set(Nan::Null());
 
-  std::string text(*String::Utf8Value(args[1]));
+  std::string text(*String::Utf8Value(info[1]));
 
-  git_repository* repo = GetRepository(args);
+  git_repository* repo = GetRepository(info);
 
   git_blob* blob = NULL;
 
-  int getBlobResult = GetBlob(args, repo, blob);
+  int getBlobResult = GetBlob(info, repo, blob);
 
   if (getBlobResult != 0)
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
 
   std::vector<LineDiff> lineDiffs;
   git_diff_options options = CreateDefaultGitDiffOptions();
 
   // Set GIT_DIFF_IGNORE_WHITESPACE_EOL when ignoreEolWhitespace: true
-  if (args.Length() >= 3) {
-    Local<Object> optionsArg(Local<Object>::Cast(args[2]));
-    if (optionsArg->Get(NanNew<String>("ignoreEolWhitespace"))->BooleanValue())
+  if (info.Length() >= 3) {
+    Local<Object> optionsArg(Local<Object>::Cast(info[2]));
+    Local<Value> ignoreEolWhitespace;
+    ignoreEolWhitespace = optionsArg->Get(
+        Nan::New<String>("ignoreEolWhitespace").ToLocalChecked());
+
+    if (ignoreEolWhitespace->BooleanValue())
       options.flags = GIT_DIFF_IGNORE_WHITESPACE_EOL;
   }
 
@@ -711,54 +731,55 @@ NAN_METHOD(Repository::GetLineDiffDetails) {
   if (git_diff_blob_to_buffer(blob, NULL, text.data(), text.length(), NULL,
                               &options, NULL, NULL, DiffLineCallback,
                               &lineDiffs) == GIT_OK) {
-    Local<Object> v8Ranges = NanNew<Array>(lineDiffs.size());
+    Local<Object> v8Ranges = Nan::New<Array>(lineDiffs.size());
     for (size_t i = 0; i < lineDiffs.size(); i++) {
-      Local<Object> v8Range = NanNew<Object>();
+      Local<Object> v8Range = Nan::New<Object>();
 
-      v8Range->Set(NanNew<String>("oldLineNumber"),
-                   NanNew<Number>(lineDiffs[i].line.old_lineno));
-      v8Range->Set(NanNew<String>("newLineNumber"),
-                   NanNew<Number>(lineDiffs[i].line.new_lineno));
-      v8Range->Set(NanNew<String>("oldStart"),
-                   NanNew<Number>(lineDiffs[i].hunk.old_start));
-      v8Range->Set(NanNew<String>("newStart"),
-                   NanNew<Number>(lineDiffs[i].hunk.new_start));
-      v8Range->Set(NanNew<String>("oldLines"),
-                   NanNew<Number>(lineDiffs[i].hunk.old_lines));
-      v8Range->Set(NanNew<String>("newLines"),
-                   NanNew<Number>(lineDiffs[i].hunk.new_lines));
-      v8Range->Set(NanNew<String>("line"),
-                   NanNew<String>(lineDiffs[i].line.content,
-                                  lineDiffs[i].line.content_len));
+      v8Range->Set(Nan::New<String>("oldLineNumber").ToLocalChecked(),
+                   Nan::New<Number>(lineDiffs[i].line.old_lineno));
+      v8Range->Set(Nan::New<String>("newLineNumber").ToLocalChecked(),
+                   Nan::New<Number>(lineDiffs[i].line.new_lineno));
+      v8Range->Set(Nan::New<String>("oldStart").ToLocalChecked(),
+                   Nan::New<Number>(lineDiffs[i].hunk.old_start));
+      v8Range->Set(Nan::New<String>("newStart").ToLocalChecked(),
+                   Nan::New<Number>(lineDiffs[i].hunk.new_start));
+      v8Range->Set(Nan::New<String>("oldLines").ToLocalChecked(),
+                   Nan::New<Number>(lineDiffs[i].hunk.old_lines));
+      v8Range->Set(Nan::New<String>("newLines").ToLocalChecked(),
+                   Nan::New<Number>(lineDiffs[i].hunk.new_lines));
+      v8Range->Set(Nan::New<String>("line").ToLocalChecked(),
+                   Nan::New<String>(lineDiffs[i].line.content,
+                                    lineDiffs[i].line.content_len)
+                                        .ToLocalChecked());
 
       v8Ranges->Set(i, v8Range);
     }
     git_blob_free(blob);
-    NanReturnValue(v8Ranges);
+    return info.GetReturnValue().Set(v8Ranges);
   } else {
     git_blob_free(blob);
-    NanReturnNull();
+    return info.GetReturnValue().Set(Nan::Null());
   }
 }
 
-Handle<Value> Repository::ConvertStringVectorToV8Array(
+Local<Value> Repository::ConvertStringVectorToV8Array(
     const std::vector<std::string>& vector) {
   size_t i = 0, size = vector.size();
-  Local<Object> array = NanNew<Array>(size);
+  Local<Object> array = Nan::New<Array>(size);
   for (i = 0; i < size; i++)
-    array->Set(i, NanNew<String>(vector[i].c_str()));
+    array->Set(i, Nan::New<String>(vector[i].c_str()).ToLocalChecked());
 
   return array;
 }
 
 NAN_METHOD(Repository::GetReferences) {
-  NanScope();
+  Nan::HandleScope scope;
 
-  Local<Object> references = NanNew<Object>();
+  Local<Object> references = Nan::New<Object>();
   std::vector<std::string> heads, remotes, tags;
 
   git_strarray strarray;
-  git_reference_list(&strarray, GetRepository(args));
+  git_reference_list(&strarray, GetRepository(info));
 
   for (unsigned int i = 0; i < strarray.count; i++)
     if (strncmp(strarray.strings[i], "refs/heads/", 11) == 0)
@@ -770,12 +791,14 @@ NAN_METHOD(Repository::GetReferences) {
 
   git_strarray_free(&strarray);
 
-  references->Set(NanNew<String>("heads"), ConvertStringVectorToV8Array(heads));
-  references->Set(NanNew<String>("remotes"),
-                  ConvertStringVectorToV8Array(remotes));
-  references->Set(NanNew<String>("tags"), ConvertStringVectorToV8Array(tags));
+  references->Set(Nan::New<String>("heads").ToLocalChecked(),
+                    ConvertStringVectorToV8Array(heads));
+  references->Set(Nan::New<String>("remotes").ToLocalChecked(),
+                    ConvertStringVectorToV8Array(remotes));
+  references->Set(Nan::New<String>("tags").ToLocalChecked(),
+                    ConvertStringVectorToV8Array(tags));
 
-  NanReturnValue(references);
+  info.GetReturnValue().Set(references);
 }
 
 int branch_checkout(git_repository* repo, const char* refName) {
@@ -799,28 +822,28 @@ int branch_checkout(git_repository* repo, const char* refName) {
 }
 
 NAN_METHOD(Repository::CheckoutReference) {
-  NanScope();
+  Nan::HandleScope scope;
 
-  if (args.Length() < 1)
-    NanReturnValue(NanNew<Boolean>(false));
+  if (info.Length() < 1)
+    return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 
   bool shouldCreateNewRef;
-  if (args.Length() > 1 && args[1]->BooleanValue())
+  if (info.Length() > 1 && info[1]->BooleanValue())
     shouldCreateNewRef = true;
   else
     shouldCreateNewRef = false;
 
-  std::string strRefName(*String::Utf8Value(args[0]));
+  std::string strRefName(*String::Utf8Value(info[0]));
   const char* refName = strRefName.c_str();
 
-  git_repository* repo = GetRepository(args);
+  git_repository* repo = GetRepository(info);
 
   if (branch_checkout(repo, refName) == GIT_OK) {
-    NanReturnValue(NanNew<Boolean>(true));
+    return info.GetReturnValue().Set(Nan::New<Boolean>(true));
   } else if (shouldCreateNewRef) {
     git_reference* head;
     if (git_repository_head(&head, repo) != GIT_OK)
-      NanReturnValue(NanNew<Boolean>(false));
+      return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 
     const git_oid* sha = git_reference_target(head);
     git_commit* commit;
@@ -828,7 +851,7 @@ NAN_METHOD(Repository::CheckoutReference) {
     git_reference_free(head);
 
     if (commitStatus != GIT_OK)
-      NanReturnValue(NanNew<Boolean>(false));
+      return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 
     git_reference* branch;
     // N.B.: git_branch_create needs a name like 'xxx', not 'refs/heads/xxx'
@@ -840,55 +863,55 @@ NAN_METHOD(Repository::CheckoutReference) {
     git_commit_free(commit);
 
     if (branchCreateStatus != GIT_OK)
-      NanReturnValue(NanNew<Boolean>(false));
+      return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 
     git_reference_free(branch);
 
     if (branch_checkout(repo, refName) == GIT_OK)
-      NanReturnValue(NanNew<Boolean>(true));
+      return info.GetReturnValue().Set(Nan::New<Boolean>(true));
   }
 
-  NanReturnValue(NanNew<Boolean>(false));
+  return info.GetReturnValue().Set(Nan::New<Boolean>(false));
 }
 
 NAN_METHOD(Repository::Add) {
-  NanScope();
+  Nan::HandleScope scope;
 
-  git_repository* repository = GetRepository(args);
-  std::string path(*String::Utf8Value(args[0]));
+  git_repository* repository = GetRepository(info);
+  std::string path(*String::Utf8Value(info[0]));
 
   git_index* index;
   if (git_repository_index(&index, repository) != GIT_OK) {
     const git_error* e = giterr_last();
     if (e != NULL)
-      return NanThrowError(e->message);
+      return Nan::ThrowError(e->message);
     else
-      return NanThrowError("Unknown error opening index");
+      return Nan::ThrowError("Unknown error opening index");
   }
   // Modify the in-memory index.
   if (git_index_add_bypath(index, path.c_str()) != GIT_OK) {
     git_index_free(index);
     const git_error* e = giterr_last();
     if (e != NULL)
-      return NanThrowError(e->message);
+      return Nan::ThrowError(e->message);
     else
-      return NanThrowError("Unknown error adding path to index");
+      return Nan::ThrowError("Unknown error adding path to index");
   }
   // Write this change in the index back to disk, so it is persistent
   if (git_index_write(index) != GIT_OK) {
     git_index_free(index);
     const git_error* e = giterr_last();
     if (e != NULL)
-      return NanThrowError(e->message);
+      return Nan::ThrowError(e->message);
     else
-      return NanThrowError("Unknown error adding path to index");
+      return Nan::ThrowError("Unknown error adding path to index");
   }
   git_index_free(index);
-  NanReturnValue(NanNew<Boolean>(true));
+  info.GetReturnValue().Set(Nan::New<Boolean>(true));
 }
 
-Repository::Repository(Handle<String> path) {
-  NanScope();
+Repository::Repository(Local<String> path) {
+  Nan::HandleScope scope;
 
   std::string repositoryPath(*String::Utf8Value(path));
   if (git_repository_open_ext(

--- a/src/repository.h
+++ b/src/repository.h
@@ -29,9 +29,9 @@
 #include "nan.h"
 using namespace v8;  // NOLINT
 
-class Repository : public node::ObjectWrap {
+class Repository : public Nan::ObjectWrap {
  public:
-  static void Init(Handle<Object> target);
+  static void Init(Local<Object> target);
 
  private:
   static NAN_METHOD(New);
@@ -72,17 +72,17 @@ class Repository : public node::ObjectWrap {
   static int SubmoduleCallback(git_submodule *submodule, const char *name,
                                void *payload);
 
-  static Handle<Value> ConvertStringVectorToV8Array(
+  static Local<Value> ConvertStringVectorToV8Array(
       const std::vector<std::string>& vector);
 
-  static git_repository* GetRepository(_NAN_METHOD_ARGS_TYPE args);
+  static git_repository* GetRepository(Nan::NAN_METHOD_ARGS_TYPE args);
 
-  static int GetBlob(_NAN_METHOD_ARGS_TYPE args,
+  static int GetBlob(Nan::NAN_METHOD_ARGS_TYPE args,
                       git_repository* repo, git_blob*& blob);
 
   static git_diff_options CreateDefaultGitDiffOptions();
 
-  explicit Repository(Handle<String> path);
+  explicit Repository(Local<String> path);
   ~Repository();
 
   git_repository* repository;


### PR DESCRIPTION
This PR updates the nan package dependency from 1.6.1 to 2.0.0. I followed the approach in a similar PR on node-nslog (atom/node-nslog#11), so this is the result of running https://gist.github.com/thlorenz/7e9d8ad15566c99fd116 on the relevant source files, appeasing cpplint and massaging the output where the script has gaps.