### PR TITLE
[RFC] Don't search for the repository

### DIFF
--- a/src/repository.cc
+++ b/src/repository.cc
@@ -914,8 +914,7 @@ Repository::Repository(Local<String> path) {
   Nan::HandleScope scope;
 
   std::string repositoryPath(*String::Utf8Value(path));
-  if (git_repository_open_ext(
-        &repository, repositoryPath.c_str(), 0, NULL) != GIT_OK)
+  if (git_repository_open(&repository, repositoryPath.c_str()) != GIT_OK)
     repository = NULL;
 }
 


### PR DESCRIPTION
This is the simplest possible fix for https://github.com/atom/atom/issues/6437 and performance issues related to that (https://github.com/atom/atom/issues/3426).

I’d like to get some feedback on this. This is the simplest solution, but it comes with the downside that if you open a subdirectory of a repository we don’t treat it as a repository. I don't know how important we consider that to be.

There are a few alternatives:

1. We could give libgit2 a list of paths at which it should stop looking for the repository, e.g., the user’s home directory. This feels a bit like playing whack-a-mole, but maybe OK for the majority case.

2. We could change git-utils to request the status using a pathspec which is the directory we actually have open in Atom. This would still require libgit2 to do a bit more work than it otherwise would, but I *think* it’d certainly be better than it is now.

/cc @atom/feedback 