### PR TITLE
Add getStatusForPaths

### DIFF
--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -471,6 +471,21 @@ describe "git", ->
         expect(_.keys(statuses).length).toBe 1
         expect(statuses['secret-stuff/b.txt']).toBe 1 << 7
 
+    describe 'when no path is specified', ->
+      it 'returns an empty object', ->
+        statuses = repo.getStatusForPaths()
+        expect(_.keys(statuses).length).toBe 0
+
+    describe 'when an empty array is specified', ->
+      it 'returns an empty object', ->
+        statuses = repo.getStatusForPaths([])
+        expect(_.keys(statuses).length).toBe 0
+
+    describe 'when an empty string is specified', ->
+      it 'returns an empty object', ->
+        statuses = repo.getStatusForPaths([''])
+        expect(_.keys(statuses).length).toBe 0
+
   describe '.getAheadBehindCount()', ->
     beforeEach ->
       repoDirectory = temp.mkdirSync('node-git-repo-')

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -453,6 +453,24 @@ describe "git", ->
       it 'returns the status of the given path', ->
         expect(repo.getStatus('a.txt')).toBe 1 << 9
 
+  describe '.getStatusForPaths([paths])', ->
+    beforeEach ->
+      repoDirectory = temp.mkdirSync('node-git-repo-')
+      wrench.copyDirSyncRecursive(path.join(__dirname, 'fixtures/master.git'), path.join(repoDirectory, '.git'))
+      repo = git.open(repoDirectory)
+
+      newDir = path.join(repo.getWorkingDirectory(), 'secret-stuff')
+      fs.mkdirSync(newDir)
+
+      newFilePath = path.join(newDir, 'b.txt')
+      fs.writeFileSync(newFilePath, '', 'utf8')
+
+    describe 'when a path is specified', ->
+      it 'returns the status of only that path', ->
+        statuses = repo.getStatusForPaths(['secret-stuff'])
+        expect(_.keys(statuses).length).toBe 1
+        expect(statuses['secret-stuff/b.txt']).toBe 1 << 7
+
   describe '.getAheadBehindCount()', ->
     beforeEach ->
       repoDirectory = temp.mkdirSync('node-git-repo-')

--- a/src/repository.cc
+++ b/src/repository.cc
@@ -330,7 +330,11 @@ NAN_METHOD(Repository::GetStatus) {
 
 NAN_METHOD(Repository::GetStatusForPaths) {
   Nan::HandleScope scope;
+
   Local<Object> result = Nan::New<Object>();
+  if (info.Length() < 1)
+    return info.GetReturnValue().Set(result);
+
   std::map<std::string, unsigned int> statuses;
   git_status_options options = GIT_STATUS_OPTIONS_INIT;
   options.flags = GIT_STATUS_OPT_INCLUDE_UNTRACKED |
@@ -339,6 +343,9 @@ NAN_METHOD(Repository::GetStatusForPaths) {
 
   Array *pathsArg = Array::Cast(*info[0]);
   unsigned int pathsLength = pathsArg->Length();
+  if (pathsLength < 1)
+    return info.GetReturnValue().Set(result);
+
   char *path = NULL;
   char **paths = reinterpret_cast<char **>(malloc(pathsLength * sizeof(path)));
   for (unsigned int i = 0; i < pathsLength; i++) {

--- a/src/repository.cc
+++ b/src/repository.cc
@@ -48,6 +48,8 @@ void Repository::Init(Local<Object> target) {
   Nan::SetMethod(proto, "getConfigValue", Repository::GetConfigValue);
   Nan::SetMethod(proto, "setConfigValue", Repository::SetConfigValue);
   Nan::SetMethod(proto, "getStatus", Repository::GetStatus);
+  Nan::SetMethod(proto, "getStatusForPaths",
+                        Repository::GetStatusForPaths);
   Nan::SetMethod(proto, "checkoutHead", Repository::CheckoutHead);
   Nan::SetMethod(proto, "getReferenceTarget", Repository::GetReferenceTarget);
   Nan::SetMethod(proto, "getDiffStats", Repository::GetDiffStats);
@@ -324,6 +326,47 @@ NAN_METHOD(Repository::GetStatus) {
     else
       return info.GetReturnValue().Set(Nan::New<Number>(0));
   }
+}
+
+NAN_METHOD(Repository::GetStatusForPaths) {
+  Nan::HandleScope scope;
+  Local<Object> result = Nan::New<Object>();
+  std::map<std::string, unsigned int> statuses;
+  git_status_options options = GIT_STATUS_OPTIONS_INIT;
+  options.flags = GIT_STATUS_OPT_INCLUDE_UNTRACKED |
+                  GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS |
+                  GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH;
+
+  Array *pathsArg = Array::Cast(*info[0]);
+  unsigned int pathsLength = pathsArg->Length();
+  char *path = NULL;
+  char **paths = reinterpret_cast<char **>(malloc(pathsLength * sizeof(path)));
+  for (unsigned int i = 0; i < pathsLength; i++) {
+    String::Utf8Value utf8Path(pathsArg->Get(i));
+    path = strdup(*utf8Path);
+    paths[i] = path;
+  }
+
+  git_strarray pathsArray;
+  pathsArray.count = pathsLength;
+  pathsArray.strings = paths;
+  options.pathspec = pathsArray;
+
+  if (git_status_foreach_ext(GetRepository(info),
+                             &options,
+                             StatusCallback,
+                             &statuses) == GIT_OK) {
+    std::map<std::string, unsigned int>::iterator iter = statuses.begin();
+    for (; iter != statuses.end(); ++iter)
+      result->Set(Nan::New<String>(iter->first.c_str()).ToLocalChecked(),
+                  Nan::New<Number>(iter->second));
+  }
+
+  if (paths != NULL) {
+    git_strarray_free(&pathsArray);
+  }
+
+  return info.GetReturnValue().Set(result);
 }
 
 NAN_METHOD(Repository::CheckoutHead) {

--- a/src/repository.h
+++ b/src/repository.h
@@ -46,6 +46,7 @@ class Repository : public Nan::ObjectWrap {
   static NAN_METHOD(GetConfigValue);
   static NAN_METHOD(SetConfigValue);
   static NAN_METHOD(GetStatus);
+  static NAN_METHOD(GetStatusForPaths);
   static NAN_METHOD(CheckoutHead);
   static NAN_METHOD(GetReferenceTarget);
   static NAN_METHOD(GetDiffStats);


### PR DESCRIPTION
(Supersedes #62.)

This will (hopefully) let us fix performance issues like https://github.com/atom/atom/issues/6437 and https://github.com/atom/atom/issues/3426.

The problem:

1. We use `git_repository_open_ext` which will search for a repository if the directory you give it isn’t a repository.
1. Some people (knowingly or unknowingly) have a git repository in their home directory.
1. We find that repository in `$HOME` and request its status.
1. Because we include `GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS` in our status options, libgit2 has to visit literally every directory in the user’s home, recursively.
1. So instead, let’s have the ability to give libgit2 a pathspec so that it knows we only care about a subdirectory within the repository.