### PR TITLE
Allow limiting search for repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ npm install git-utils
 
 ## Docs
 
-### git.open(path)
+### git.open(path, [search = true])
 
 Open the repository at the given path.  This will return `null` if the
 repository at the given path does not exist or cannot be opened.
+
+`path` - The path from which to try to open a repository
+`search` - Set to false if we shouldn't search up in the directory tree
 
 ```coffeescript
 git = require 'git-utils'
@@ -32,6 +35,11 @@ repository = git.open('/Users/me/repos/node')
 The opened repository will have a `submodules` property that will be an object
 of paths mapped to submodule {Repository} objects. The path keys will be
 relative to the opened repository's working directory.
+
+If search is set to true (the default), all paths up to the filesystem root will
+be recursively checked to try and find the root directory of a repository. If a
+search is false, traversing not be performed, and a repository will only be
+returned if the given path is the root of a repository.
 
 ### Repository.checkoutHead(path)
 

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -28,6 +28,11 @@ describe "git", ->
       it "returns null", ->
         expect(git.open('/tmp/path/does/not/exist')).toBeNull()
 
+    describe "when limiting upwards traversal", ->
+      it "returns null", ->
+        repositorySubdirectoryPath = path.join(path.dirname(__dirname), 'spec', 'fixtures')
+        expect(git.open(repositorySubdirectoryPath, false)).toBeNull()
+
   describe ".getPath()", ->
     it "returns the path to the .git directory", ->
       repositoryPath = git.open(__dirname).getPath()

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -197,11 +197,10 @@ isRootPath = (repositoryPath) ->
   else
     repositoryPath is path.sep
 
-openRepository = (repositoryPath) ->
+openRepository = (repositoryPath, search = true) ->
   symlink = realpath(repositoryPath) isnt repositoryPath
-
   repositoryPath = repositoryPath.replace(/\\/g, '/') if process.platform is 'win32'
-  repository = new Repository(repositoryPath)
+  repository = new Repository(repositoryPath, search)
   if repository.exists()
     repository.caseInsensitiveFs = fs.isCaseInsensitive()
     if symlink
@@ -226,7 +225,7 @@ openSubmodules = (repository) ->
         openSubmodules(submoduleRepo)
         repository.submodules[relativePath] = submoduleRepo
 
-exports.open = (repositoryPath) ->
-  repository = openRepository(repositoryPath)
+exports.open = (repositoryPath, search = true) ->
+  repository = openRepository(repositoryPath, search)
   openSubmodules(repository) if repository?
   repository

--- a/src/repository.cc
+++ b/src/repository.cc
@@ -72,7 +72,8 @@ NODE_MODULE(git, Repository::Init)
 
 NAN_METHOD(Repository::New) {
   Nan::HandleScope scope;
-  Repository* repository = new Repository(Local<String>::Cast(info[0]));
+  Repository* repository = new Repository(
+    Local<String>::Cast(info[0]), Local<Boolean>::Cast(info[1]));
   repository->Wrap(info.This());
   info.GetReturnValue().SetUndefined();
 }
@@ -962,12 +963,16 @@ NAN_METHOD(Repository::Add) {
   info.GetReturnValue().Set(Nan::New<Boolean>(true));
 }
 
-Repository::Repository(Local<String> path) {
+Repository::Repository(Local<String> path, Local<Boolean> search) {
   Nan::HandleScope scope;
+
+  int flags = 0;
+  if (!search->BooleanValue())
+    flags |= GIT_REPOSITORY_OPEN_NO_SEARCH;
 
   std::string repositoryPath(*String::Utf8Value(path));
   if (git_repository_open_ext(
-        &repository, repositoryPath.c_str(), 0, NULL) != GIT_OK)
+        &repository, repositoryPath.c_str(), flags, NULL) != GIT_OK)
     repository = NULL;
 }
 

--- a/src/repository.h
+++ b/src/repository.h
@@ -83,7 +83,7 @@ class Repository : public Nan::ObjectWrap {
 
   static git_diff_options CreateDefaultGitDiffOptions();
 
-  explicit Repository(Local<String> path);
+  explicit Repository(Local<String> path, Local<Boolean> search);
   ~Repository();
 
   git_repository* repository;


### PR DESCRIPTION
In some cases it is useful to only open a repository if the given path points to it directly, and not travese up the directory tree trying to find one.

Specifically, I'm hoping to address an issue described in atom/find-and-replace#910, where when the editor is opened on an otherwise-ignored directory within a repository (e.g. via `bundle open`). With this change, I can modify https://github.com/atom/scandal/blob/master/src/path-filter.coffee#L86 to only consider git ignores when the root directory of the editor is the root of a git repository, which is the behaviour most users expect.

This is my first time working with atom code, and with Nan specifically, so please forgive any lapses in style or technique - I'm very happy to revise with any feedback you might have. Thanks!