### PR TITLE
package-lock.json: Fix misformed URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1595,7 +1595,7 @@
       "integrity": "sha1-uDx1fIAOaOHW78GjoaE/85/23NI=",
       "dev": true,
       "requires": {
-        "jasmine-node": "jasmine-node@git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+        "jasmine-node": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
         "underscore-plus": "1.x",
         "walkdir": "0.0.7"
       },
@@ -1625,7 +1625,7 @@
     },
     "jasmine-node": {
       "version": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
-      "from": "jasmine-node@git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+      "from": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
       "dev": true,
       "requires": {
         "coffee-script": ">=1.0.1",


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix (from template, click to expand)</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

I get an error during `npm install` due to misformed URLs:

```console
% npm install                 
npm ERR! code ENOLOCAL
npm ERR! Could not install from "node_modules/jasmine-focused/jasmine-node@git+https:/github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef" as it does not contain a package.json file.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/[user]/.npm/_logs/2020-12-30T23_38_03_316Z-debug.log

```

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Update some URLs in `package-lock.json` that got recorded strangely at some point.

<details>

These invalid URLs have the package name prepended. But a valid URL in this case starts with the protocol (`git+https://`) not the package name (`jasmine-node`).

```diff
-        "jasmine-node": "jasmine-node@git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+        "jasmine-node": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
```

_(Git history detective work: Looks like these URLs were unknowingly changed to this strange format in an unrelated PR: https://github.com/atom/git-utils/pull/97. For what it's worth, I saw this error before in the apm repo: https://github.com/atom/apm/pull/875#issuecomment-620958597 and used the same fix.)_

</details>

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Just delete `package-lock.json` and run `npm install` to generate a totally fresh lockfile, as was done in https://github.com/atom/git-utils/pull/104.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

`npm install` succeeds now on my computer. CI should pass.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A