### PR TITLE
.npmignore: Ignore heavy, unused parts of libgit2

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,8 @@
 /build
 /spec
 /deps/libgit2/build
+/deps/libgit2/fuzzers
+/deps/libgit2/tests
 /deps/libgit2/tests-clar
 *.a
 *.o


### PR DESCRIPTION
<details>
<summary>Requirements for Contributing a Performance Improvement (from template, click to expand)</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only affect performance of existing functionality. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Add the `tests` and `fuzzers` sub-directories of `deps/libgit2` to `.npmignore`.

This prevents these files from being included in the published package. The files are about 41.6 MB, the vast majority of `libgit2`'s size. These files are apparently not used by `git-utils` at all.

### Quantitative Performance Benefits

<!--

Describe the exact performance improvement observed (for example, reduced time to complete an operation, reduced memory use, etc.). Describe how you measured this change. Bonus points for including graphs that demonstrate the improvement or attached dumps from the built-in profiling tools.

-->

<details><summary>Benchmark setup steps (click to expand)</summary>

"Before" results:

```
mkdir experiments && cd experiments
mkdir a && cd a
npm init -y
npm install DeeDeeG/git-utils --ignore-scripts
# wait for this to finish installing...
npm ci --ignore-scripts
```

Example output:

```console
[user]@[host] a % npm ci --ignore-scripts
npm WARN prepare removing existing node_modules/ before installation
added 20 packages in 10.84s
```

"After" results: 

In another terminal window, do:

```
cd experiments
mkdir b && cd b
npm init -y
npm install DeeDeeG/git-utils#npmignore-heavy-libgit2-stuff --ignore-scripts
# wait for this to finish installing...
npm ci --ignore-scripts
```

Example output:

```console
[user]@[host] b % npm ci --ignore-scripts
added 20 packages in 1.436s
```

</details>

#### Faster package extraction:

- Windows (slow laptop, HDD, CPU-bound)
  - Before: 90-100 seconds
  - After: 12-13 seconds

- macOS (faster laptop, HDD)
  - Before: 10-12 seconds
  - After: 1.5-2 seconds

#### Other benefits:

The compressed tarball of this package goes down from 5MB to 1.5MB (measured with `ls -lh`). The expanded contents go down from 49.0MB to 7.6MB (measured with `ncdu`). I hope these filesize savings speak for themselves.

Wit this change, the package goes from containing 13023 files/folders down to 627 files/folders.

This saves network time downloading the package (this benefit varies by your network speed), saves time copying the files around on disk (especially relevant on Windows; Windows is very slow at writing lots of small files), saves disk space... The benefits of not shipping unused files are many, even though they can be subtle at times.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

This repository's tests pass, `apm`'s tests pass when including this updated package, and Atom's tests pass when including this updated package.

<details><summary>Lots of details with regard to verifying that this change works, including links to passing CI (click to expand)</summary>

Packed the tarball with `npm pack`. Installed this tarball in small dummy npm projects:

- `mkdir dummy_project && cd dummy_project && npm init -y`
- `npm install ../path/to/git-utils-5.7.0.tgz`

Tarball installs successfully, including building `libgit2`.

Also modified a local copy of the `apm` repo to use this branch of `git-util`... and ran CI; `apm`'s own tests pass with this change. 
- [Travis CI](https://travis-ci.com/github/DeeDeeG/apm/builds/211447133)
- [AppVeyor](https://ci.appveyor.com/project/DeeDeeG/apm/builds/37063262)

Atom's tests pass when using `git-utils` with this change.
- [Azure Pipelines](https://dev.azure.com/DeeDeeG/b/_build/results?buildId=957)

Furthermore, I confirmed that this repository's own tests can pass without these files present under `deps/libgit2/`.

</details>

### Applicable Issues

<!-- Enter any applicable Issues here -->

None.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Reduced package size by .npmignore-ing unused files from libgit2